### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/includes/wpmudev-metaboxes/ui/colorpicker/js/jquery.js
+++ b/includes/wpmudev-metaboxes/ui/colorpicker/js/jquery.js
@@ -587,6 +587,11 @@ jQuery.extend = jQuery.fn.extend = function() {
 		if ( (options = arguments[ i ]) != null )
 			// Extend the base object
 			for ( var name in options ) {
+				// Skip dangerous properties to prevent prototype pollution
+				if (name === "__proto__" || name === "constructor") {
+					continue;
+				}
+
 				var src = target[ name ], copy = options[ name ];
 
 				// Prevent never-ending loop


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/marketpress/security/code-scanning/1](https://github.com/cp-psource/marketpress/security/code-scanning/1)

To fix the prototype pollution vulnerability in the `jQuery.extend` function:
1. Add a check to block the special property names `__proto__` and `constructor` from being copied to the target object.
2. Ensure that these checks are applied both in shallow and deep copy scenarios.

The fix involves modifying the loop on line 589 to skip these dangerous property names. This can be done by adding a conditional check before processing each property.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
