### PR TITLE
Potential fix for code scanning alert no. 24: Incomplete multi-character sanitization

### DIFF
--- a/ui/colorpicker/js/jquery.js
+++ b/ui/colorpicker/js/jquery.js
@@ -3270,7 +3270,14 @@ jQuery.fn.extend({
 						jQuery("<div/>")
 							// inject the contents of the document in, removing the scripts
 							// to avoid any 'Permission Denied' errors in IE
-							.append(res.responseText.replace(/<script(.|\s)*?\/script>/g, ""))
+							.append((function sanitize(input) {
+								let previous;
+								do {
+									previous = input;
+									input = input.replace(/<script(.|\s)*?\/script>/g, "");
+								} while (input !== previous);
+								return input;
+							})(res.responseText))
 
 							// Locate the specified elements
 							.find(selector) :


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/marketpress/security/code-scanning/24](https://github.com/cp-psource/marketpress/security/code-scanning/24)

To fix the issue, we need to ensure that all `<script>` tags, including nested or malformed ones, are completely removed from the input. The best approach is to repeatedly apply the regular expression replacement until no more matches are found. This ensures that any residual `<script>` tags left behind after the first pass are also removed. Alternatively, we could use a well-tested library like `sanitize-html` for robust sanitization, but since the code is part of a legacy jQuery library, we'll stick to the repeated replacement approach to minimize external dependencies.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
