### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe jQuery plugin

### DIFF
--- a/includes/admin/ui/js/repeatable-fields.js
+++ b/includes/admin/ui/js/repeatable-fields.js
@@ -30,7 +30,7 @@
         initialize( this );
 
         function initialize( parent ) {
-            $( settings.wrapper, parent ).each( function( index, element ) {
+            $( parent ).find( settings.wrapper ).each( function( index, element ) {
                 var wrapper = this;
 
                 var container = $( wrapper ).children( settings.container );


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/marketpress/security/code-scanning/3](https://github.com/cp-psource/marketpress/security/code-scanning/3)

To fix the issue, we need to ensure that the `settings.wrapper` value is always treated as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of `jQuery` for selecting elements. The `jQuery.find` method interprets the input strictly as a CSS selector, preventing it from being treated as HTML.

The changes will involve:
1. Replacing the `$( settings.wrapper, parent )` call on line 33 with `$( parent ).find( settings.wrapper )`.
2. Ensuring that similar changes are applied to other instances where `settings.wrapper` or other user-provided settings are used as selectors.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
