### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete multi-character sanitization

### DIFF
--- a/includes/wpmudev-metaboxes/ui/colorpicker/js/jquery.js
+++ b/includes/wpmudev-metaboxes/ui/colorpicker/js/jquery.js
@@ -3275,7 +3275,14 @@ jQuery.fn.extend({
 						jQuery("<div/>")
 							// inject the contents of the document in, removing the scripts
 							// to avoid any 'Permission Denied' errors in IE
-							.append(res.responseText.replace(/<script(.|\s)*?\/script>/g, ""))
+							.append((function sanitize(input) {
+								let previous;
+								do {
+									previous = input;
+									input = input.replace(/<script(.|\s)*?\/script>/g, "");
+								} while (input !== previous);
+								return input;
+							})(res.responseText))
 
 							// Locate the specified elements
 							.find(selector) :


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/marketpress/security/code-scanning/23](https://github.com/cp-psource/marketpress/security/code-scanning/23)

To fix the issue, we need to ensure that all `<script>` tags, including nested or malformed ones, are completely removed from the input. A robust approach is to repeatedly apply the regular expression replacement until no more matches are found. This ensures that any residual `<script>` tags left behind by the initial replacement are also removed. Alternatively, we could use a well-tested library like `sanitize-html` to handle the sanitization, but since we are limited to the provided code, we will implement the repeated replacement approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
