### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete string escaping or encoding

### DIFF
--- a/ui/select2/select2.js
+++ b/ui/select2/select2.js
@@ -698,6 +698,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.containerId="s2id_"+(opts.element.attr("id") || "autogen"+nextUid());
             this.containerEventName= this.containerId
+                .replace(/\\/g, '\\\\') // Escape backslashes
                 .replace(/([.])/g, '_')
                 .replace(/([;&,\-\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, '\\$1');
             this.container.attr("id", this.containerId);


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/marketpress/security/code-scanning/22](https://github.com/cp-psource/marketpress/security/code-scanning/22)

To fix the issue, we need to ensure that backslashes are properly escaped in addition to the other special characters. This can be achieved by adding a `replace` call to handle backslashes before the existing `replace` calls. Specifically:
1. Add a `replace` call to escape backslashes (`\`) by replacing them with double backslashes (`\\`).
2. Ensure that this new `replace` call is applied before the existing ones to avoid conflicts or unintended behavior.

The fix will modify the code on line 700 to include this additional escaping step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
