### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete string escaping or encoding

### DIFF
--- a/includes/wpmudev-metaboxes/ui/select2/select2.js
+++ b/includes/wpmudev-metaboxes/ui/select2/select2.js
@@ -698,6 +698,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.containerId="s2id_"+(opts.element.attr("id") || "autogen"+nextUid());
             this.containerEventName= this.containerId
+                .replace(/\\/g, '\\\\') // Escape backslashes
                 .replace(/([.])/g, '_')
                 .replace(/([;&,\-\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, '\\$1');
             this.container.attr("id", this.containerId);


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/marketpress/security/code-scanning/20](https://github.com/cp-psource/marketpress/security/code-scanning/20)

To fix the issue, we need to ensure that backslashes in the input are properly escaped. This can be achieved by adding a `replace` call to handle backslashes before escaping other special characters. Specifically:
1. Add a `replace` call to escape backslashes (`\`) by replacing them with double backslashes (`\\`).
2. Ensure that this new `replace` call is applied before the existing `replace` calls on lines 701 and 702.

This fix ensures that all occurrences of backslashes are escaped, preventing potential issues when the string is used in contexts where backslashes have special meaning.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
