### PR TITLE
Potential fix for code scanning alert no. 21: Incomplete string escaping or encoding

### DIFF
--- a/ui/js/mp-cart.js
+++ b/ui/js/mp-cart.js
@@ -4,7 +4,7 @@
  * @since 3.0
  */
 String.prototype.escapeSelector = function() {
-    return this.replace( /(:|\.|\[|\])/g, "\\$1" );
+    return this.replace( /([:\\.\\[\\]\\\\])/g, "\\$1" );
 };
 
 var mp_cart = { };


### PR DESCRIPTION
Potential fix for [https://github.com/cp-psource/marketpress/security/code-scanning/21](https://github.com/cp-psource/marketpress/security/code-scanning/21)

To fix the issue, we need to ensure that backslashes are also escaped in the `escapeSelector` function. This can be achieved by modifying the regular expression to include backslashes as a target for escaping. Additionally, we should ensure that the escaping is applied globally to all occurrences of the targeted characters.

The updated regular expression will include a backslash (`\\`) as one of the characters to be escaped. The replacement string will remain `\\$1`, which ensures that the matched character is prefixed with a backslash.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
